### PR TITLE
Implement life loss on pepe coin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <title>Poop-Boss Sewer Run</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="icon" href="favicon.ico" />
 
   <!-- Phaser 3 -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>

--- a/docs/main.js
+++ b/docs/main.js
@@ -38,6 +38,7 @@ let dropTimer;
 let posScore = 0,
   scoreText;
 let lifeIcons = [];
+let lives = MAX_LIVES;
 
 /* -------- PRELOAD -------- */
 function preload() {
@@ -73,6 +74,11 @@ function preload() {
 /* ───────── CREATE ───────── */
 function create() {
   const { width, height } = this.scale;
+
+  // reset HUD state on scene start
+  lifeIcons = [];
+  lives = MAX_LIVES;
+  posScore = 0;
 
   /* world bounds – הרצפה 100px מעל תחתית, קירות מכל הצדדים */
   this.physics.world.setBounds(0, 0, width, height - WORLD_FLOOR_PAD);
@@ -186,6 +192,11 @@ function collectCoin(player, coin) {
   if (coin.texture.key === "coinPos") {
     posScore += 1;
     scoreText.setText("POS: " + posScore);
+  } else if (coin.texture.key === "coinPepe") {
+    if (lives > 0) {
+      lifeIcons[MAX_LIVES - lives].setVisible(false);
+      lives -= 1;
+    }
   }
   coin.destroy();
 }


### PR DESCRIPTION
## Summary
- reset HUD elements when the scene starts
- introduce `lives` counter to track remaining icons
- remove a life icon when collecting a `coinPepe`
- fix missing favicon by referencing it in `index.html`

## Testing
- `npx eslint docs/main.js` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6854cd41a19883298c4022ddd2c62fd7