### PR TITLE
Add 2s pause after speech bubble

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -340,7 +340,7 @@ function showTaunt(scene) {
       if (index < words.length) {
         scene.time.delayedCall(600, typeNext);
       } else {
-        scene.time.delayedCall(500, () => {
+        scene.time.delayedCall(2000, () => {
           pepe.destroy();
           bubble.destroy();
           text.destroy();


### PR DESCRIPTION
## Summary
- add a 2-second delay after the text in the speech bubble is complete

## Testing
- `pytest` (no tests found)
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854ea60028083298e64c68c249a9533