### PR TITLE
Add Telegram scoring hook

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -310,9 +310,22 @@ class GameOverScene extends Phaser.Scene {
     const { width, height } = this.scale;
     this.add.image(width / 2, height / 2, 'flushed');
     this.sound.play('gameOverSound');
+    postScoreToTelegram(posScore);
     const toStart = () => this.scene.start('start');
     this.input.keyboard.once('keydown', toStart);
     this.input.once('pointerdown', toStart);
+  }
+}
+
+/* send score to Telegram WebApp if available */
+function postScoreToTelegram(score) {
+  try {
+    const tg = window.Telegram && window.Telegram.WebApp;
+    if (tg && typeof tg.postEvent === 'function') {
+      tg.postEvent(`score:${score}`);
+    }
+  } catch (e) {
+    /* ignore errors when Telegram is unavailable */
   }
 }
 


### PR DESCRIPTION
## Summary
- send final score via Telegram WebApp when the player loses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68550f8448308329a1ef7b478dba7b9b