### PR TITLE
Add debugging for posting score

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -321,11 +321,18 @@ class GameOverScene extends Phaser.Scene {
 function postScoreToTelegram(score) {
   try {
     const tg = window.Telegram && window.Telegram.WebApp;
+    console.debug('[GameOver] postScoreToTelegram called', {
+      score,
+      tgExists: !!tg,
+    });
     if (tg && typeof tg.postEvent === 'function') {
       tg.postEvent(`score:${score}`);
+      console.debug('[GameOver] score posted:', score);
+    } else {
+      console.debug('[GameOver] Telegram interface unavailable');
     }
   } catch (e) {
-    /* ignore errors when Telegram is unavailable */
+    console.error('[GameOver] failed posting score:', e);
   }
 }
 


### PR DESCRIPTION
## Summary
- log when attempting to post the score to Telegram

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557cd23ffc8329a0a5c0297b7570ba