### PR TITLE
Add on-screen debug HUD

### DIFF
--- a/docs/debugHud.js
+++ b/docs/debugHud.js
@@ -1,0 +1,35 @@
+export default class DebugHudPlugin extends Phaser.Plugins.ScenePlugin {
+  constructor(scene, pluginManager) {
+    super(scene, pluginManager);
+    this.lines = [];
+    this.text = null;
+    this.enabled = true;
+  }
+
+  boot() {
+    this.text = this.scene.add
+      .text(10, 10, '', {
+        font: '14px monospace',
+        fill: '#00ff00',
+        align: 'left',
+      })
+      .setDepth(1000)
+      .setScrollFactor(0);
+    this.scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.shutdown, this);
+  }
+
+  shutdown() {
+    if (this.text) {
+      this.text.destroy();
+      this.text = null;
+    }
+    this.lines = [];
+  }
+
+  print(msg) {
+    if (!this.enabled || !this.text) return;
+    this.lines.push(msg);
+    if (this.lines.length > 5) this.lines.shift();
+    this.text.setText(this.lines);
+  }
+}

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,4 +1,5 @@
 // main.js
+import DebugHudPlugin from './debugHud.js';
 
 /* ───────── CONFIG ───────── */
 const GAME_W = 720,
@@ -310,7 +311,7 @@ class GameOverScene extends Phaser.Scene {
     const { width, height } = this.scale;
     this.add.image(width / 2, height / 2, 'flushed');
     this.sound.play('gameOverSound');
-    postScoreToTelegram(posScore);
+    postScoreToTelegram(this, posScore);
     const toStart = () => this.scene.start('start');
     this.input.keyboard.once('keydown', toStart);
     this.input.once('pointerdown', toStart);
@@ -318,21 +319,18 @@ class GameOverScene extends Phaser.Scene {
 }
 
 /* send score to Telegram WebApp if available */
-function postScoreToTelegram(score) {
+function postScoreToTelegram(scene, score) {
   try {
     const tg = window.Telegram && window.Telegram.WebApp;
-    console.debug('[GameOver] postScoreToTelegram called', {
-      score,
-      tgExists: !!tg,
-    });
+    scene.debugHud.print('[GameOver] postScoreToTelegram called');
     if (tg && typeof tg.postEvent === 'function') {
       tg.postEvent(`score:${score}`);
-      console.debug('[GameOver] score posted:', score);
+      scene.debugHud.print('[GameOver] score posted: ' + score);
     } else {
-      console.debug('[GameOver] Telegram interface unavailable');
+      scene.debugHud.print('[GameOver] Telegram interface unavailable');
     }
   } catch (e) {
-    console.error('[GameOver] failed posting score:', e);
+    scene.debugHud.print('[GameOver] failed posting score: ' + e);
   }
 }
 
@@ -501,6 +499,11 @@ const config = {
   physics: {
     default: 'arcade',
     arcade: { gravity: { y: WORLD_GRAVITY }, debug: false },
+  },
+  plugins: {
+    scene: [
+      { key: 'debugHud', plugin: DebugHudPlugin, mapping: 'debugHud' },
+    ],
   },
   scene: [BootScene, StartScene, GameScene, GameOverScene],
 };


### PR DESCRIPTION
## Summary
- add `debugHud.js` Scene Plugin for debug messaging
- configure Phaser game to load the plugin
- display debug messages in game over scene via the plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685581e66fa88329a45abb2d34896120