### PR TITLE
Fix README file list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ You can use any other static HTTP server if preferred.
 
 ```
 /docs        # Game HTML, JS and assets
-/main.py     # Sample Python script (not used by the game)
+/LICENSE     # License information
+/README.md   # Project documentation
+/.gitignore  # Files ignored by git
 ```
 
 `docs/index.html` bootstraps Phaser and loads `main.js`, which contains all game logic.


### PR DESCRIPTION
## Summary
- delete the nonexistent `main.py` reference
- list only files that actually exist in the repo

## Testing
- `grep -n "main.py" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68559061155c83299e6324271b1889a8