### PR TITLE
Add hosting & bot info

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,18 @@ You can use any other static HTTP server if preferred.
 
 `docs/index.html` bootstraps Phaser and loads `main.js`, which contains all game logic.
 
+
+## Hosting Over HTTPS and Bot Registration
+
+Hosting `docs/` on an HTTPS capable server is required for the Telegram gaming platform. One simple approach is GitHub Pages:
+
+1. Push this repository to GitHub.
+2. In the repository settings enable **GitHub Pages** and select `docs/` as the source.
+3. Once published the game will be available at an HTTPS URL such as `https://<user>.github.io/<repo>/`.
+
+Register that URL with your bot using @BotFather when creating the game. After the game has a `short_name` and URL you can interact with it via the Bot API:
+
+- **sendGame** - share the game in chat so users can play: `https://api.telegram.org/bot<BOT_TOKEN>/sendGame`.
+- **setGameScore** - update a user's score after each run: `https://api.telegram.org/bot<BOT_TOKEN>/setGameScore`.
+
+Players can open the game directly using the short link `t.me/<bot>?game=<short_name>`. Update your bot logic to call `sendGame` and `setGameScore` accordingly whenever the user's score changes.


### PR DESCRIPTION
## Summary
- explain hosting the docs folder on HTTPS
- document how to register a Telegram game and update scores

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685594f9eb88832998861a6f8d17ee62