### PR TITLE
Improve Telegram score handling

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -367,6 +367,22 @@ function postScoreToTelegram(scene, score) {
     ) {
       window.TelegramGameProxy.postEvent('score', score);
       scene.debugHud.print('[GameOver] score sent via GameProxy: ' + score);
+    } else if (webApp && webApp.initDataUnsafe && webApp.initDataUnsafe.user) {
+      const params = {
+        user_id: webApp.initDataUnsafe.user.id,
+        score,
+      };
+      if (webApp.initDataUnsafe.chat)
+        params.chat_id = webApp.initDataUnsafe.chat.id;
+      if (webApp.initDataUnsafe.inline_message_id)
+        params.inline_message_id = webApp.initDataUnsafe.inline_message_id;
+      fetch('/setscore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+      }).then(() =>
+        scene.debugHud.print('[GameOver] score sent via fallback API: ' + score)
+      );
     } else {
       scene.debugHud.print('[GameOver] Telegram interface unavailable');
     }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,27 @@ const API_URL = `https://api.telegram.org/bot${BOT_TOKEN}`;
 const app = express();
 app.use(express.json());
 
+app.post('/setscore', async (req, res) => {
+  const { user_id, chat_id, inline_message_id, score } = req.body || {};
+  if (!user_id || score === undefined) {
+    return res.status(400).json({ error: 'user_id and score required' });
+  }
+  const params = {
+    user_id: Number(user_id),
+    score: Number(score),
+    force: true,
+  };
+  if (chat_id) params.chat_id = Number(chat_id);
+  if (inline_message_id) params.inline_message_id = inline_message_id;
+  try {
+    const result = await tgApi('setGameScore', params);
+    res.json(result);
+  } catch (e) {
+    console.error('Failed setting score:', e);
+    res.status(500).json({ error: 'failed' });
+  }
+});
+
 function tgApi(method, params) {
   return fetch(`${API_URL}/${method}`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- add a `/setscore` endpoint for posting scores from the client
- fallback to `/setscore` in `postScoreToTelegram`

## Testing
- `node --check server.js`
- `node --check docs/main.js`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68561e03ce5083298c0f315408920ac4