### PR TITLE
Use Telegram WebApp init data for scores

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,8 @@
 
   <!-- Phaser 3 -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+  <!-- Telegram WebApp interface -->
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
 
   <style>
     html,body{margin:0;padding:0;background:#000}


### PR DESCRIPTION
## Summary
- load telegram-web-app.js in the HTML
- verify WebApp context when the game loads
- send the final score to the server using initData
- simplify leaderboard calls
- update server to validate initData and remove old webhook logic

## Testing
- `node -e "require('./server.js');"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685620c7a33c83298a5b70f19a6e08d5