### PR TITLE
Add sendGame fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Hosting `docs/` on an HTTPS capable server is required for the Telegram WebApp p
 2. In the repository settings enable **GitHub Pages** and select `docs/` as the source.
 3. Once published the game will be available at an HTTPS URL such as `https://<user>.github.io/<repo>/`.
 
-Register that URL with your bot using @BotFather. The game must be opened as a Telegram **WebApp**; the legacy `sendGame` flow is incompatible with the code in `docs/main.js`.
+Register that URL with your bot using @BotFather. The game works best as a Telegram **WebApp**. A limited fallback for the legacy `sendGame` method is included, though the scoreboard is disabled in that mode.
 
 Use an inline keyboard button to launch the WebApp. Example with **python-telegram-bot**:
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,13 +1,14 @@
 // main.js
 import DebugHudPlugin from './debugHud.js';
 
-// Ensure the game runs inside Telegram WebApp
-const tg = window.Telegram && window.Telegram.WebApp;
-if (!tg || !tg.initData) {
+// Ensure the game runs inside Telegram
+const tgWebApp = window.Telegram && window.Telegram.WebApp;
+const tgGameProxy = window.TelegramGameProxy;
+if (!tgWebApp && !tgGameProxy) {
   alert('Please open this game in Telegram.');
-  throw new Error('Not in Telegram WebApp environment');
+  throw new Error('Not in Telegram environment');
 }
-tg.ready();
+if (tgWebApp) tgWebApp.ready();
 
 /* ───────── CONFIG ───────── */
 const GAME_W = 720,


### PR DESCRIPTION
## Summary
- allow launching `docs/main.js` via legacy `sendGame`
- mention fallback in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685628e6e0148329b112172fc32448f3