### PR TITLE
Add server setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,29 @@ After receiving the score data from `main.js`, call `setGameScore` as usual to u
 
 If you also want the server to post the final score to a Telegram chat, set the
 `GROUP_CHAT_ID` environment variable when running `server.js`.
+
+## Running `server.js`
+
+The provided `server.js` script can be used to serve `docs/` and forward scores
+to Telegram. It requires **Node.js 18** or newer. Before running it install the
+minimal dependencies:
+
+```bash
+npm install express node-fetch
+```
+
+Start the server with your bot token:
+
+```bash
+BOT_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11 \
+  node server.js
+```
+
+`BOT_TOKEN` is mandatory. Set `GROUP_CHAT_ID` as well if you want the server to
+post scores to a specific chat:
+
+```bash
+GROUP_CHAT_ID="-1001234567890" BOT_TOKEN=<token> node server.js
+```
+
+The server listens on port `3000` by default.


### PR DESCRIPTION
## Summary
- document how to run the Node.js server
- mention installing `express` and `node-fetch`
- explain required `BOT_TOKEN` and optional `GROUP_CHAT_ID`

## Testing
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_6856382dbc4c83298a9f9bbfdd5d5745