### PR TITLE
Add BOT_TOKEN startup validation

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const crypto = require('crypto');
 const BOT_TOKEN = process.env.BOT_TOKEN;
 if (!BOT_TOKEN) {
   console.error('BOT_TOKEN environment variable not set');
+  process.exit(1);
 }
 const GROUP_CHAT_ID = process.env.GROUP_CHAT_ID;
 if (!GROUP_CHAT_ID) {


### PR DESCRIPTION
## Summary
- exit early when BOT_TOKEN is missing

## Testing
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_6856383332788329975a2ebaa7bfd0ef