### PR TITLE
Use Telegram WebApp only for score submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Hosting `docs/` on an HTTPS capable server is required for the Telegram WebApp p
 2. In the repository settings enable **GitHub Pages** and select `docs/` as the source.
 3. Once published the game will be available at an HTTPS URL such as `https://<user>.github.io/<repo>/`.
 
-Register that URL with your bot using @BotFather. The game works best as a Telegram **WebApp**. A limited fallback for the legacy `sendGame` method is included, though the scoreboard is disabled in that mode.
+Register that URL with your bot using @BotFather. The game requires the Telegram **WebApp** platform.
 
 Use an inline keyboard button to launch the WebApp. Example with **python-telegram-bot**:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,8 +11,6 @@
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
   <!-- Telegram WebApp interface -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <!-- Telegram Game interface for sendGame -->
-  <script src="https://telegram.org/js/games.js"></script>
 
   <style>
     html,body{margin:0;padding:0;background:#000}


### PR DESCRIPTION
## Summary
- remove Telegram games.js script
- drop legacy sendGame/HTTP score handling
- require WebApp environment in JS startup
- update README to note WebApp requirement

## Testing
- `node -e "require('./docs/main.js');"` *(fails: Phaser not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685732926f888329a4991d1c7581f916