### PR TITLE
Show Telegram username on start screen

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -9,6 +9,10 @@ if (!tgWebApp) {
 }
 tgWebApp.ready();
 
+// Extract Telegram user data for greetings
+const tgUser = tgWebApp.initDataUnsafe?.user;
+const WELCOME_NAME = tgUser ? tgUser.username || tgUser.id : null;
+
 /* ───────── CONFIG ───────── */
 const GAME_W = 720,
   GAME_H = 1280;
@@ -140,6 +144,14 @@ class StartScene extends Phaser.Scene {
   create() {
     const { width, height } = this.scale;
     this.add.image(width / 2, height / 2, 'tapStart');
+    if (WELCOME_NAME) {
+      this.add
+        .text(width / 2, height - 100, `Welcome ${WELCOME_NAME}!`, {
+          font: '32px Impact',
+          fill: '#ffffff',
+        })
+        .setOrigin(0.5);
+    }
     const startGame = () => {
       this.sound.play('startSound');
       this.scene.start('game');


### PR DESCRIPTION
## Summary
- extract Telegram user info when the WebApp loads
- display a welcome line in `StartScene` using the Telegram username or ID

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685751a880c88329b12555f40cb32baf