### PR TITLE
Integrate Supabase score storage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,8 @@
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
   <!-- Telegram WebApp interface -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <!-- Supabase client -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js/dist/umd/supabase.min.js"></script>
 
   <style>
     html,body{margin:0;padding:0;background:#000}

--- a/docs/main.js
+++ b/docs/main.js
@@ -13,6 +13,18 @@ tgWebApp.ready();
 const tgUser = tgWebApp.initDataUnsafe?.user;
 const WELCOME_NAME = tgUser ? tgUser.username || tgUser.id : null;
 
+/* ───────── SUPABASE CLIENT ───────── */
+const SB_URL = 'https://msdijjqgqbqqgjyrcwxm.supabase.co';
+const SB_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1zZGlqanFncWJxcWdqeXJjd3htIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTA1NTA4MDIsImV4cCI6MjA2NjEyNjgwMn0.VKLQZjfJFmsbZPWIhx6J3yusgtKRLSiWjsO5GoBh_X8';
+const supabase = supabase.createClient(SB_URL, SB_KEY);
+
+async function saveScoreToDB(tgId, username, score) {
+  const { error } = await supabase
+    .from('scores')
+    .insert({ tg_user_id: tgId, username, score });
+  if (error) console.error('Supabase insert error:', error);
+}
+
 /* ───────── CONFIG ───────── */
 const GAME_W = 720,
   GAME_H = 1280;
@@ -332,6 +344,8 @@ class GameOverScene extends Phaser.Scene {
     this.add.image(width / 2, height / 2, 'flushed');
     this.sound.play('gameOverSound');
     sendScoreToTelegram(this, posScore);
+    // Save to Supabase too
+    saveScoreToDB(tgUser?.id, WELCOME_NAME || 'unknown', posScore);
     this.time.delayedCall(1500, () => this.scene.start('leaderboard'));
   }
 }


### PR DESCRIPTION
## Summary
- load Supabase client in index.html
- add Supabase client setup in main.js
- save score to Supabase when game ends

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68575ca6a3d88329bb360b7566eac517